### PR TITLE
reorganized tracks and artists

### DIFF
--- a/app/components/TopItems.tsx
+++ b/app/components/TopItems.tsx
@@ -2,6 +2,9 @@
 import { useSession } from "next-auth/react"
 import { useEffect, useState } from "react"
 
+let track_limit = 6
+let artist_limit = 8
+
 interface Artist {
   name: string
   images: { url: string }[]
@@ -22,7 +25,7 @@ interface TopItems {
   tracks: Track[]
 }
 
-// three ranges that spotify has data for: 4 weeks, 6 months, All Time 
+// Three ranges that Spotify has data for: 4 weeks, 6 months, All Time
 type TimeRange = "short_term" | "medium_term" | "long_term"
 
 export default function TopItems() {
@@ -36,10 +39,10 @@ export default function TopItems() {
       try {
         setLoading(true)
         console.log("Fetching with token:", session.token.access_token)
-        
+
         // Fetch top artists
         const artistsResponse = await fetch(
-          `https://api.spotify.com/v1/me/top/artists?limit=5&time_range=${range}`,
+          `https://api.spotify.com/v1/me/top/artists?limit=${artist_limit}&time_range=${range}`,
           {
             headers: {
               Authorization: `Bearer ${session.token.access_token}`,
@@ -51,7 +54,7 @@ export default function TopItems() {
 
         // Fetch top tracks
         const tracksResponse = await fetch(
-          `https://api.spotify.com/v1/me/top/tracks?limit=5&time_range=${range}`,
+          `https://api.spotify.com/v1/me/top/tracks?limit=${track_limit}&time_range=${range}`,
           {
             headers: {
               Authorization: `Bearer ${session.token.access_token}`,
@@ -130,60 +133,67 @@ export default function TopItems() {
         </button>
       </div>
 
-      {/* Top Artists */}
-      <div className="bg-gray-800 rounded-lg p-6">
-        <h2 className="text-2xl font-bold text-white mb-4">Top Artists</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="flex justify-between">
+        {/* Top Artists */}
+        <div className="bg-gray-800 rounded-lg p-6">
+          <h2 className="text-2xl font-bold text-white mb-4">Top Artists</h2>
           {topItems.artists && topItems.artists.length > 0 ? (
-            topItems.artists.map((artist, index) => (
-              <div key={index} className="bg-gray-700 rounded-lg p-4">
-                {artist.images?.[0] && (
-                  <img
-                    src={artist.images[0].url}
-                    alt={artist.name}
-                    className="w-full h-48 object-cover rounded-lg mb-2"
-                  />
-                )}
-                <h3 className="text-xl font-semibold text-white">{artist.name}</h3>
-                {artist.genres && artist.genres.length > 0 && (
-                  <p className="text-gray-300 text-sm">
-                    {artist.genres.slice(0, 2).join(", ")}
-                  </p>
-                )}
-              </div>
-            ))
+            <ul className="space-y-3">
+              {topItems.artists.map((artist, index) => (
+                <li
+                  key={index}
+                  className="flex items-center space-x-4 bg-gray-700 rounded-lg p-3 w-100"
+                >
+                  {artist.images?.[0] && (
+                    <img
+                      src={artist.images[0].url}
+                      alt={artist.name}
+                      className="w-12 h-12 rounded-full object-cover"
+                    />
+                  )}
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{artist.name}</h3>
+                    {artist.genres && artist.genres.length > 0 && (
+                      <p className="text-gray-300 text-sm">
+                        {artist.genres.slice(0, 2).join(", ")}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
           ) : (
             <p className="text-gray-300">No artists found</p>
           )}
         </div>
-      </div>
 
-      {/* Top Tracks */}
-      <div className="bg-gray-800 rounded-lg p-6">
-        <h2 className="text-2xl font-bold text-white mb-4">Top Tracks</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {topItems.tracks && topItems.tracks.length > 0 ? (
-            topItems.tracks.map((track, index) => (
-              <div key={index} className="bg-gray-700 rounded-lg p-4">
-                {track.album?.images?.[0] && (
-                  <img
-                    src={track.album.images[0].url}
-                    alt={track.name}
-                    className="w-full h-48 object-cover rounded-lg mb-2"
-                  />
-                )}
-                <h3 className="text-xl font-semibold text-white">{track.name}</h3>
-                <p className="text-gray-300">
-                  {track.artists.map((artist) => artist.name).join(", ")}
-                </p>
-                <p className="text-gray-400 text-sm">{track.album.name}</p>
-              </div>
-            ))
-          ) : (
-            <p className="text-gray-300">No tracks found</p>
-          )}
+        {/* Top Tracks */}
+        <div className="bg-gray-800 rounded-lg p-6 ml-3">
+          <h2 className="text-2xl font-bold text-white mb-4">Top Tracks</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {topItems.tracks && topItems.tracks.length > 0 ? (
+              topItems.tracks.map((track, index) => (
+                <div key={index} className="bg-gray-700 rounded-lg p-4">
+                  {track.album?.images?.[0] && (
+                    <img
+                      src={track.album.images[0].url}
+                      alt={track.name}
+                      className="w-full h-48 object-cover rounded-lg mb-2"
+                    />
+                  )}
+                  <h3 className="text-l font-semibold text-white">{track.name}</h3>
+                  <p className="text-gray-300">
+                    {track.artists.map((artist) => artist.name).join(", ")}
+                  </p>
+                  <p className="text-gray-400 text-xs">{track.album.name}</p>
+                </div>
+              ))
+            ) : (
+              <p className="text-gray-300">No tracks found</p>
+            )}
+          </div>
         </div>
       </div>
     </div>
   )
-} 
+}

--- a/app/components/TopItems.tsx
+++ b/app/components/TopItems.tsx
@@ -178,10 +178,10 @@ export default function TopItems() {
                     <img
                       src={track.album.images[0].url}
                       alt={track.name}
-                      className="w-full h-48 object-cover rounded-lg mb-2"
+                      className="w-64 h-64 object-cover rounded-lg mb-2 m-auto"
                     />
                   )}
-                  <h3 className="text-l font-semibold text-white">{track.name}</h3>
+                  <h3 className="text-l font-semibold text-white mt-5">{track.name}</h3>
                   <p className="text-gray-300">
                     {track.artists.map((artist) => artist.name).join(", ")}
                   </p>


### PR DESCRIPTION
I reorganized the Tailwind CSS for tracks and artists to have a list and more organized block format. I added in small variables to be able to change the number of visible tracks and artists. The intention is to have the graphs and charts section below this.